### PR TITLE
Configure apps for remote deployment by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN <<EOF cat >> /stop-supervisor.sh
 #!/usr/bin/env bash
 set -Eeo pipefail
 while read -r; do
-  echo -e "\e[31m Service was stopped or one of it's services crashed,
+  echo -e "\e[31m Service was stopped or one of its services crashed,
             see the logs above for more details. \e[0m" >&2
   kill -SIGTERM "$(cat supervisord.pid)"
 done < /dev/stdin
@@ -47,7 +47,7 @@ stderr_logfile_maxbytes=0
 
 [program:notebook-server]
 directory=/app/
-command=jupyter notebook --allow-root --no-browser --NotebookApp.base_url=/jupyter --NotebookApp.allow_origin='*' --port=8888 --ip=0.0.0.0
+command=jupyter notebook --allow-root --no-browser --ServerApp.base_url=/jupyter --ServerApp.allow_origin='*' --port=8888 --ip=0.0.0.0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stdout

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ EOL
 1. If the story embeddings have been generated as above, you should load the collection's story texts first by running `just add-collection [COLLECTION_NAME] [ORGANIZATION] [COUNTRY] [LANGUAGE]`, then `just add-embeddings [COLLECTION_NAME]`  
 If you prefer to generate the story embeddings within the Docker containers while simultaneously importing them along with the story texts, run `just add-collection-and-calculate-embeddings [COLLECTION_NAME] [ORGANIZATION] [COUNTRY] [LANGUAGE]` instead.
 1. The search and browse interface for the collections and embeddings should be available at [http://localhost:808/isebelle](http://localhost:8080/isebelle)
+
+## Deploying to a server
+
+The installation steps above (including the Docker setup) should be sufficient to run ISEBELLE on a remote server. Some reverse proxy configuration of the web server may be needed to make the site accessible via the web, however. The following configurations have been successfully used with Apache, although the Jupyter functionality is not fully tested yet.
+
+```sh
+# Route URLs beginning with /isebelle or /jupyter to the Docker containers
+ProxyPass /isebelle http://127.0.0.1:8080/isebelle
+ProxyPass /jupyter http://127.0.0.1:8080/jupyter
+
+# Attempt also to route websocket requests to Docker (for Jupyter support)
+RewriteEngine On
+RewriteCond %{REQUEST_URI}  ^/socket.io            [NC]
+RewriteCond %{QUERY_STRING} transport=websocket    [NC]
+RewriteRule /(.*)           ws://localhost:8080/$1 [P,L]
+```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you prefer to generate the story embeddings within the Docker containers whil
 The installation steps above (including the Docker setup) should be sufficient to run ISEBELLE on a remote server. Some reverse proxy configuration of the web server may be needed to make the site accessible via the web, however. The following configurations have been successfully used with Apache, although the Jupyter functionality is not fully tested yet.
 
 ```sh
-# Route URLs beginning with /isebelle or /jupyter to the Docker containers
+# Route paths beginning with /isebelle or /jupyter to the Docker containers
 ProxyPass /isebelle http://127.0.0.1:8080/isebelle
 ProxyPass /jupyter http://127.0.0.1:8080/jupyter
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# isebelle
+# ISEBELLE
 Intelligent Search Engine for Belief Legend Embeddings
 
 ## Installation
@@ -29,4 +29,4 @@ EOL
 1. It can be faster to generate the story sentence embeddings outside of the Docker containers, by running `python api/create_collection_embeddings.py --collection-path [PATH_TO_COLLECTION_FOLDER]`, but in this case you will need to install the script's dependencies on your own.
 1. If the story embeddings have been generated as above, you should load the collection's story texts first by running `just add-collection [COLLECTION_NAME] [ORGANIZATION] [COUNTRY] [LANGUAGE]`, then `just add-embeddings [COLLECTION_NAME]`  
 If you prefer to generate the story embeddings within the Docker containers while simultaneously importing them along with the story texts, run `just add-collection-and-calculate-embeddings [COLLECTION_NAME] [ORGANIZATION] [COUNTRY] [LANGUAGE]` instead.
-1. The search and browse interface for the collections and embeddings should be available at [http://localhost:8080](http://localhost:8080)
+1. The search and browse interface for the collections and embeddings should be available at [http://localhost:808/isebelle](http://localhost:8080/isebelle)

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -47,7 +47,7 @@ stderr_logfile_maxbytes=0
 
 [program:notebook-server]
 directory=/app/
-command=jupyter notebook --allow-root --no-browser --NotebookApp.base_url=/jupyter --NotebookApp.allow_origin='*' --port=8888 --ip=0.0.0.0
+command=jupyter notebook --allow-root --no-browser --ServerApp.base_url=/jupyter --ServerApp.allow_origin='*' --port=8888 --ip=0.0.0.0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stdout

--- a/api/isebelle_db/_read_only.py
+++ b/api/isebelle_db/_read_only.py
@@ -45,7 +45,7 @@ async def get_collection_stories(
     self, collection_id: UUID, start: int, count: int
 ) -> list:
     return await self._pool.fetch(
-        """SELECT story_id, collection_name, search_language, text, text_embedding FROM story
+        """SELECT story_id, collection_name, search_language, text FROM story
             WHERE collection_id = $1 ORDER BY story_id LIMIT $3 OFFSET $2;
         """,
         collection_id,

--- a/api/isebelle_db/_text_search.py
+++ b/api/isebelle_db/_text_search.py
@@ -13,6 +13,7 @@ async def lexical_search(
         f"""
         SELECT
             story_id,
+            collection_name
             search_language,
             text,
             ts_rank(search_text, query) AS rank

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.black]
 line-length = 89
-target-version = ['py310']
+target-version = ['py312']
 
 [tool.ruff]
-extend-exclude = ["notebooks", "lib/yolox", "lib/transnetv2", "lib/poem"]
+extend-exclude = ["notebooks"]
 ignore = []
 line-length = 89
 select = ["B","C","E","F","T","W","B9","I"]
 src = ["api"]
 
 [tool.ruff.isort]
-known-first-party = ["lib", "mime_db"]
+known-first-party = ["lib", "isebelle_db"]
 known-local-folder = ["api"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: 5432
-      PUBLIC_API_BASE: /api
+      PUBLIC_API_BASE: /isebelle/api
 
       DB_NAME: ${DB_NAME:?}
       DB_USER: ${DB_USER:?}
@@ -34,13 +34,12 @@ services:
       - ./web-ui:/app:Z
 
     environment:
-      PUBLIC_API_BASE: /api
+      PUBLIC_API_BASE: /isebelle/api
       COREPACK_ENABLE_AUTO_PIN: 0
 
   db:
     container_name: isebelle-db
     image: ankane/pgvector
-
     shm_size: 1g
 
     volumes:

--- a/nginx.config
+++ b/nginx.config
@@ -35,24 +35,15 @@ server {
     try_files $uri $uri/ @dev-ui-proxy;
   }
 
-  location /api/ {
+  location /isebelle/api/ {
     proxy_pass http://api:5000/;
   }
 
-  location /jupyter {
+  location /isebelle/jupyter {
     proxy_pass http://api:8888;
   }
 
-  location ~ /jupyter/api/kernels/ {
-    proxy_pass http://api:8888;
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
-  }
-
-  location ~ /jupyter/terminals/ {
+  location ~ /isebelle/jupyter/api/kernels/ {
     proxy_pass http://api:8888;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
@@ -61,7 +52,16 @@ server {
     proxy_read_timeout 86400;
   }
 
-  location ~* /jupyter/(\d+)/(.*) {
+  location ~ /isebelle/jupyter/terminals/ {
+    proxy_pass http://api:8888;
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 86400;
+  }
+
+  location ~* /isebelle/jupyter/(\d+)/(.*) {
     resolver 127.0.0.11 ipv6=off;
     proxy_pass http://api:$1/$2$is_args$args;
   }

--- a/nginx.config
+++ b/nginx.config
@@ -39,20 +39,11 @@ server {
     proxy_pass http://api:5000/;
   }
 
-  location /isebelle/jupyter {
+  location /jupyter {
     proxy_pass http://api:8888;
   }
 
-  location ~ /isebelle/jupyter/api/kernels/ {
-    proxy_pass http://api:8888;
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
-  }
-
-  location ~ /isebelle/jupyter/terminals/ {
+  location ~ /jupyter/api/kernels/ {
     proxy_pass http://api:8888;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
@@ -61,7 +52,16 @@ server {
     proxy_read_timeout 86400;
   }
 
-  location ~* /isebelle/jupyter/(\d+)/(.*) {
+  location ~ /jupyter/terminals/ {
+    proxy_pass http://api:8888;
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 86400;
+  }
+
+  location ~* /jupyter/(\d+)/(.*) {
     resolver 127.0.0.11 ipv6=off;
     proxy_pass http://api:$1/$2$is_args$args;
   }

--- a/nginx.tls.config
+++ b/nginx.tls.config
@@ -35,24 +35,15 @@ server {
     try_files $uri $uri/ @dev-ui-proxy;
   }
 
-  location /api/ {
+  location /isebelle/api/ {
     proxy_pass http://api:5000/;
   }
 
-  location /jupyter {
+  location /isebelle/jupyter {
     proxy_pass http://api:8888;
   }
 
-  location ~ /jupyter/api/kernels/ {
-    proxy_pass http://api:8888;
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
-  }
-
-  location ~ /jupyter/terminals/ {
+  location ~ /isebelle/jupyter/api/kernels/ {
     proxy_pass http://api:8888;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
@@ -61,7 +52,16 @@ server {
     proxy_read_timeout 86400;
   }
 
-  location ~* /jupyter/(\d+)/(.*) {
+  location ~ /isebelle/jupyter/terminals/ {
+    proxy_pass http://api:8888;
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 86400;
+  }
+
+  location ~* /isebelle/jupyter/(\d+)/(.*) {
     resolver 127.0.0.11 ipv6=off;
     proxy_pass http://api:$1/$2$is_args$args;
   }

--- a/nginx.tls.config
+++ b/nginx.tls.config
@@ -39,20 +39,11 @@ server {
     proxy_pass http://api:5000/;
   }
 
-  location /isebelle/jupyter {
+  location /jupyter {
     proxy_pass http://api:8888;
   }
 
-  location ~ /isebelle/jupyter/api/kernels/ {
-    proxy_pass http://api:8888;
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
-  }
-
-  location ~ /isebelle/jupyter/terminals/ {
+  location ~ /jupyter/api/kernels/ {
     proxy_pass http://api:8888;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
@@ -61,7 +52,16 @@ server {
     proxy_read_timeout 86400;
   }
 
-  location ~* /isebelle/jupyter/(\d+)/(.*) {
+  location ~ /jupyter/terminals/ {
+    proxy_pass http://api:8888;
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 86400;
+  }
+
+  location ~* /jupyter/(\d+)/(.*) {
     resolver 127.0.0.11 ipv6=off;
     proxy_pass http://api:$1/$2$is_args$args;
   }

--- a/web-ui/src/routes/+layout.svelte
+++ b/web-ui/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 			icon={Search}
 			text="Search"
 			href="{base}/browse/"
-			isSelected={$page.url.pathname == `${base}/browse`}
+			isSelected={$page.url.pathname == `${base}/browse/`}
 		/>
 		<!-- <SideNavLink
 			icon={ChartScatter}
@@ -61,8 +61,8 @@
 		<SideNavLink
 			icon={LogoJupyter}
 			text="Notebooks"
-			href="{base}/jupyter/tree/notebooks/"
-			isSelected={$page.url.pathname == `${base}/jupyter`}
+			href="/jupyter/tree/notebooks/"
+			isSelected={$page.url.pathname == `/jupyter/tree/notebooks/`}
 		/>
 		<SideNavDivider />
 		<SideNavLink icon={LogoGithub} text="GitHub" href="https://github.com/broadwell/isebelle" />

--- a/web-ui/src/routes/+page.svelte
+++ b/web-ui/src/routes/+page.svelte
@@ -11,27 +11,27 @@
 	<h1>Isebelle: Intelligent Search Engine for BELief Legend Embeddings</h1>
 	<div class="logo-row">
 		<a href="https://isebel.edu"
-			><img src="/static/IsebelLogoMedium.jpg" alt="ISEBEL project logo" /></a
+			><img src="{base}/static/IsebelLogoMedium.jpg" alt="ISEBEL project logo" /></a
 		>
 		<a href=""
 			><img
-				src="/static/comp_foklore_berkeley.png"
+				src="{base}/static/comp_foklore_berkeley.png"
 				alt="Logo of the UC Berkeley Computational Folklore Lab"
 			/></a
 		>
 		<a href="https://www.verhalenbank.nl/"
-			><img src="/static/logo_Meertens.png" alt="Logo of the Meertens Institut" /></a
+			><img src="{base}/static/logo_Meertens.png" alt="Logo of the Meertens Institut" /></a
 		>
 		<a href="https://www.wossidia.de/"
-			><img src="/static/wossidia4isebel.svg" alt="Logo of the Wossidia Archive" /></a
+			><img src="{base}/static/wossidia4isebel.svg" alt="Logo of the Wossidia Archive" /></a
 		>
 	</div>
 	<div class="logo-row">
 		<a href="https://ismus.is/tjodfraedi/sagnir/"
-			><img src="/static/Sagnagrunnur.png" alt="Logo of the Sagnagrunnur project" /></a
+			><img src="{base}/static/Sagnagrunnur.png" alt="Logo of the Sagnagrunnur project" /></a
 		>
 		<a href="https://samla.no/viewer/index/"
-			><img src="/static/Samla_black.svg" alt="Logo of the SAMLA project" /></a
+			><img src="{base}/static/Samla_black.svg" alt="Logo of the SAMLA project" /></a
 		>
 	</div>
 </section>

--- a/web-ui/src/routes/browse/+page.svelte
+++ b/web-ui/src/routes/browse/+page.svelte
@@ -39,6 +39,7 @@
 	};
 
 	const rowClicked = (/** @type {CustomEvent} */ clickEvent) => {
+		if (clickEvent.detail.row === undefined) return;
 		goto(`${base}/collection/${clickEvent.detail.row.id}`);
 	};
 </script>

--- a/web-ui/src/routes/browse/+page.svelte
+++ b/web-ui/src/routes/browse/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { DataTable, Search } from 'carbon-components-svelte';
+	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 
@@ -15,7 +16,7 @@
 	];
 
 	const searchEmbeddings = () => {
-		goto(`/embeddings/${searchQuery}?collection_ids=${selectedRowIds.join('|')}&limit=1000`);
+		goto(`${base}/embeddings/${searchQuery}?collection_ids=${selectedRowIds.join('|')}&limit=1000`);
 	};
 
 	const getCollectionRows = async () => {
@@ -38,7 +39,7 @@
 	};
 
 	const rowClicked = (/** @type {CustomEvent} */ clickEvent) => {
-		goto(`/collection/${clickEvent.detail.row.id}`);
+		goto(`${base}/collection/${clickEvent.detail.row.id}`);
 	};
 </script>
 

--- a/web-ui/src/routes/collection/[id]/+page.svelte
+++ b/web-ui/src/routes/collection/[id]/+page.svelte
@@ -14,8 +14,7 @@
 
 	const headers = [
 		{ key: 'id', value: 'ID' },
-		{ key: 'collection', value: 'Collection' },
-		{ key: 'language', value: 'Language' },
+		{ key: 'search_language', value: 'Language' },
 		{ key: 'text', value: 'Text' },
 		{ key: 'text_embedding', value: 'Explore' }
 		//{ key: 'chunk_count', value: 'Chunks' }
@@ -59,10 +58,9 @@
 			.then((data) =>
 				data.map((/** @type {StoryRecord} */ story) => ({
 					id: story.story_id,
-					collection: story.collection_name,
-					language: story.search_language.replace(/^./, (str) => str.toUpperCase()),
-					text: story.text,
-					embedding: story.text_embedding
+					collection_name: story.collection_name,
+					search_language: story.search_language.replace(/^./, (str) => str.toUpperCase()),
+					text: story.text
 					//chunks_count: story.chunks.toLocaleString()
 				}))
 			);
@@ -106,7 +104,7 @@
 			{#if cell.key === 'text_embedding'}
 				<Link
 					icon={Launch}
-					href={`${base}/similar/${row.id}?collection=${row.collection}`}
+					href={`${base}/similar/${row.id}?collection=${collectionName}`}
 					target="_blank">Similar</Link
 				>
 			{:else}

--- a/web-ui/src/routes/collection/[id]/+page.svelte
+++ b/web-ui/src/routes/collection/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { DataTable, Link, Pagination, Search } from 'carbon-components-svelte';
 	import Launch from 'carbon-icons-svelte/lib/Launch.svelte';
+	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 
@@ -21,7 +22,7 @@
 	];
 
 	const searchTexts = () => {
-		goto(`/search/${collectionId}?query=${searchQuery}&limit=10000`);
+		goto(`${base}/search/${collectionId}?query=${searchQuery}&limit=10000`);
 	};
 
 	const updatePagination = (/** @type {CustomEvent} */ paginationEvent) => {
@@ -31,7 +32,7 @@
 			paginationEvent.detail.pageSize != searchParams.get('pageSize')
 		)
 			goto(
-				`/collection/${collectionId}?page=${paginationEvent.detail.page}&pageSize=${paginationEvent.detail.pageSize}`
+				`${base}/collection/${collectionId}?page=${paginationEvent.detail.page}&pageSize=${paginationEvent.detail.pageSize}`
 			);
 	};
 
@@ -103,8 +104,10 @@
 		/>
 		<svelte:fragment slot="cell" let:row let:cell>
 			{#if cell.key === 'text_embedding'}
-				<Link icon={Launch} href={`/similar/${row.id}?collection=${row.collection}`} target="_blank"
-					>Similar</Link
+				<Link
+					icon={Launch}
+					href={`${base}/similar/${row.id}?collection=${row.collection}`}
+					target="_blank">Similar</Link
 				>
 			{:else}
 				{cell.value}

--- a/web-ui/src/routes/embeddings/[query]/+page.svelte
+++ b/web-ui/src/routes/embeddings/[query]/+page.svelte
@@ -1,8 +1,8 @@
 <script>
 	import { DataTable, Link, Pagination } from 'carbon-components-svelte';
 	import Launch from 'carbon-icons-svelte/lib/Launch.svelte';
+	import { base } from '$app/paths';
 	import { page } from '$app/stores';
-	// import { goto } from '$app/navigation';
 
 	let /** @type {Number} */ currentPage = $state(1);
 	let /** @type {Number} */ pageSize = $state(10);
@@ -83,8 +83,10 @@
 	>
 		<svelte:fragment slot="cell" let:row let:cell>
 			{#if cell.key === 'text_embedding'}
-				<Link icon={Launch} href={`/similar/${row.id}?collection=${row.collection}`} target="_blank"
-					>Similar</Link
+				<Link
+					icon={Launch}
+					href={`${base}/similar/${row.id}?collection=${row.collection}`}
+					target="_blank">Similar</Link
 				>
 			{:else}
 				{cell.value}

--- a/web-ui/src/routes/search/[collection_id]/+page.svelte
+++ b/web-ui/src/routes/search/[collection_id]/+page.svelte
@@ -1,7 +1,6 @@
 <script>
 	import { DataTable, Pagination } from 'carbon-components-svelte';
 	import { page } from '$app/stores';
-	// import { goto } from '$app/navigation';
 
 	let /** @type {Number} */ currentPage = $state(1);
 	let /** @type {Number} */ pageSize = $state(10);

--- a/web-ui/src/routes/search/[collection_id]/+page.svelte
+++ b/web-ui/src/routes/search/[collection_id]/+page.svelte
@@ -1,5 +1,7 @@
 <script>
-	import { DataTable, Pagination } from 'carbon-components-svelte';
+	import { DataTable, Link, Pagination } from 'carbon-components-svelte';
+	import Launch from 'carbon-icons-svelte/lib/Launch.svelte';
+	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 
 	let /** @type {Number} */ currentPage = $state(1);
@@ -12,9 +14,9 @@
 
 	const headers = [
 		{ key: 'id', value: 'ID' },
-		{ key: 'language', value: 'Language' },
 		{ key: 'text', value: 'Text' },
-		{ key: 'rank', value: 'Search Rank' }
+		{ key: 'rank', value: 'Search Rank' },
+		{ key: 'text_embedding', value: 'Explore' }
 		//{ key: 'chunk_count', value: 'Chunks' }
 	];
 
@@ -47,8 +49,8 @@
 			.then((data) =>
 				data.map((/** @type {StoryRecord} */ story) => ({
 					id: story.story_id,
-					language: story.search_language.replace(/^./, (str) => str.toUpperCase()),
 					text: story.text,
+					text_embedding: story.text_embedding,
 					rank: Math.round(story.rank * 1000) / 1000
 					//chunks_count: story.chunks.toLocaleString()
 				}))
@@ -77,5 +79,17 @@
 		size="tall"
 		{headers}
 		rows={filterRows(rows)}
-	></DataTable>
+	>
+		<svelte:fragment slot="cell" let:row let:cell>
+			{#if cell.key === 'text_embedding'}
+				<Link
+					icon={Launch}
+					href={`${base}/similar/${row.id}?collection=${collectionName.replaceAll(' ', '_')}`}
+					target="_blank">Similar</Link
+				>
+			{:else}
+				{cell.value}
+			{/if}
+		</svelte:fragment>
+	</DataTable>
 {/await}

--- a/web-ui/src/routes/similar/[story_id]/+page.svelte
+++ b/web-ui/src/routes/similar/[story_id]/+page.svelte
@@ -71,7 +71,7 @@
 	/>
 	<DataTable
 		title={'Matching stories in the selected collections'}
-		description="Similar to story {storyId} from {storyCollectionName}"
+		description="Similar to story {storyId} from {storyCollectionName.replaceAll('_', ' ')}"
 		zebra
 		size="tall"
 		{headers}
@@ -81,7 +81,7 @@
 			{#if cell.key === 'text_embedding'}
 				<Link
 					icon={Launch}
-					href={`${base}/similar/${row.id}?collection={row.collection}`}
+					href={`${base}/similar/${row.id}?collection=${row.collection}`}
 					target="_blank">Similar</Link
 				>
 			{:else}

--- a/web-ui/src/routes/similar/[story_id]/+page.svelte
+++ b/web-ui/src/routes/similar/[story_id]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { DataTable, Link, Pagination } from 'carbon-components-svelte';
 	import Launch from 'carbon-icons-svelte/lib/Launch.svelte';
+	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 
 	let /** @type {Number} */ currentPage = $state(1);
@@ -78,8 +79,10 @@
 	>
 		<svelte:fragment slot="cell" let:row let:cell>
 			{#if cell.key === 'text_embedding'}
-				<Link icon={Launch} href={`/similar/${row.id}?collection={row.collection}`} target="_blank"
-					>Similar</Link
+				<Link
+					icon={Launch}
+					href={`${base}/similar/${row.id}?collection={row.collection}`}
+					target="_blank">Similar</Link
 				>
 			{:else}
 				{cell.value}

--- a/web-ui/svelte.config.js
+++ b/web-ui/svelte.config.js
@@ -13,7 +13,7 @@ const config = {
 			fallback: '404.html'
 		}),
 		paths: {
-			base: ''
+			base: '/isebelle'
 		},
 		alias: {
 			'@': './src',


### PR DESCRIPTION
This mostly just involves prefixing the majority of URL paths with `isebelle/` so that the Dockerized apps all can be accessed (and potentially reverse-proxied) via that path prefix, rather than needing to camp out on the root path of a remote server.